### PR TITLE
feat(caplin-versioning): adds branch descriptor

### DIFF
--- a/caplin-versioning/dist.js
+++ b/caplin-versioning/dist.js
@@ -7,10 +7,11 @@ exports.default = createFullVersion;
 
 var _child_process = require('child_process');
 
-function getHash() {
+function getHash(hashLength) {
 	return new Promise(resolve => {
 		(0, _child_process.exec)('git rev-parse HEAD', (error, stdout) => {
-			resolve(stdout);
+			const hash = stdout.trim().substr(0, hashLength);
+			resolve(hash);
 		});
 	});
 }
@@ -18,18 +19,31 @@ function getHash() {
 function getCommitCount() {
 	return new Promise(resolve => {
 		(0, _child_process.exec)('git rev-list --count HEAD', (error, stdout) => {
-			resolve(stdout);
+			const count = stdout.trim();
+			resolve(count);
 		});
 	});
 }
 
-function createFullVersion(semVer, hashLength = 8) {
-	return Promise.all([getCommitCount(), getHash()]).then(output => new Promise(resolve => {
-		const commitCount = output[0].trim();
-		const gitHash = output[1].trim().substr(0, hashLength);
-		const version = `${ semVer }-${ commitCount }-${ gitHash }`;
+function getBranchDescriptor(defaultBranchName) {
+	return new Promise(resolve => {
+		(0, _child_process.exec)('git rev-parse --abbrev-ref HEAD', (error, stdout) => {
+			const descriptor = stdout === defaultBranchName ? null : stdout;
+			resolve(descriptor);
+		});
+	});
+}
 
-		resolve(version);
+function createFullVersion(semVer, { hashLength = 8, masterBranchName = 'master' }) {
+	return Promise.all([getCommitCount(), getHash(hashLength), getBranchDescriptor(defaultBranchName)]).then(output => new Promise(resolve => {
+		const versionTokens = output.reduce((acc, item) => {
+			if (item !== null) {
+				acc.push(item);
+				return acc;
+			}
+		}, [semVer]);
+
+		resolve(versionTokens.join('-'));
 	}));
 }
 

--- a/caplin-versioning/dist.js
+++ b/caplin-versioning/dist.js
@@ -28,22 +28,19 @@ function getCommitCount() {
 function getBranchDescriptor(defaultBranchName) {
 	return new Promise(resolve => {
 		(0, _child_process.exec)('git rev-parse --abbrev-ref HEAD', (error, stdout) => {
-			const descriptor = stdout === defaultBranchName ? null : stdout;
+			const currentBranch = stdout.trim();
+			const descriptor = currentBranch === defaultBranchName ? null : currentBranch;
 			resolve(descriptor);
 		});
 	});
 }
 
 function createFullVersion(semVer, { hashLength = 8, masterBranchName = 'master' }) {
-	return Promise.all([getCommitCount(), getHash(hashLength), getBranchDescriptor(defaultBranchName)]).then(output => new Promise(resolve => {
-		const versionTokens = output.reduce((acc, item) => {
-			if (item !== null) {
-				acc.push(item);
-				return acc;
-			}
-		}, [semVer]);
-
-		resolve(versionTokens.join('-'));
-	}));
+	return Promise.all([getCommitCount(), getHash(hashLength), getBranchDescriptor(masterBranchName)]).then(output => output.reduce((acc, item) => {
+		if (item !== null) {
+			acc.push(item);
+		}
+		return acc;
+	}, [semVer]).join('-'));
 }
 

--- a/caplin-versioning/index.js
+++ b/caplin-versioning/index.js
@@ -31,7 +31,8 @@ function getBranchDescriptor(defaultBranchName) {
 		exec(
 			'git rev-parse --abbrev-ref HEAD',
 			(error, stdout) => {
-				const descriptor = stdout === defaultBranchName ? null : stdout;
+				const currentBranch = stdout.trim();
+				const descriptor = currentBranch === defaultBranchName ? null : currentBranch;
 				resolve(descriptor);
 			}
 		);
@@ -43,23 +44,17 @@ export default function createFullVersion(semVer, { hashLength = 8, masterBranch
 		.all([
 			getCommitCount(),
 			getHash(hashLength),
-			getBranchDescriptor(defaultBranchName)
+			getBranchDescriptor(masterBranchName)
 		])
 		.then(
-			(output) => new Promise(
-				(resolve) => {
-					const versionTokens = output.reduce(
-						(acc, item) => {
-							if (item !== null) {
-								acc.push(item);
-								return acc;
-							}
-						},
-						[semVer]
-					);
-
-					resolve(versionTokens.join('-'));
-				}
-			)
+			output => output.reduce(
+				(acc, item) => {
+					if (item !== null) {
+						acc.push(item);
+					}
+					return acc;
+				},
+				[semVer]
+			).join('-')
 		);
 }

--- a/caplin-versioning/package.json
+++ b/caplin-versioning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caplin/versioning",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Caplin's standard versioning schema",
   "main": "dist.js",
   "scripts": {


### PR DESCRIPTION
 - the `createFullVersion` function signature has changed to allow invoking
   code to pass the master branch name as well as the git commit hash
   length limit.
 - If the branch retrieved from git matches the master branch name, the
   branch descriptor descriptor suffix is not applied to the full version
   string.
 - The function expects that projects use master as the main project branch,
   if another branch is used as main, the caller is expected to provide
   `masterBranchName`.
 - minor version bump `1.1.4` -> `1.2.0` to reflect backward breaking change
   caused by the signature change.