### PR TITLE
CT5UP-38: Add chrome headless as a browser option.

### DIFF
--- a/karma-test-runner/dist/utils.js
+++ b/karma-test-runner/dist/utils.js
@@ -36,6 +36,8 @@ function getTestBrowser(commandLineArgs) {
       return "Firefox";
     case "chrome":
       return "Chrome";
+    case "chrome-headless":
+      return "ChromeHeadless";
 
     default:
       console.log(`${selectedBrowser} is not a supported browser, defaulting to Chrome`);

--- a/karma-test-runner/package.json
+++ b/karma-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caplin/karma-test-runner",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Package that allows running all the UTs and ATs in a package using Karma",
   "main": "dist/index.js",
   "scripts": {

--- a/karma-test-runner/src/utils.js
+++ b/karma-test-runner/src/utils.js
@@ -1,29 +1,25 @@
 const { Server } = require("karma");
 
 function runOnlyATs(args) {
-  return (
-    args.ats ||
+  return args.ats ||
     args.ATs ||
     args._.includes("--ats") ||
     args._.includes("--ATs") ||
     args._.includes("ats") ||
     args._.includes("ATs") ||
-    false
-  );
+    false;
 }
 
 module.exports.runOnlyATs = runOnlyATs;
 
 function runOnlyUTs(args) {
-  return (
-    args.uts ||
+  return args.uts ||
     args.UTs ||
     args._.includes("--uts") ||
     args._.includes("--UTs") ||
     args._.includes("uts") ||
     args._.includes("UTs") ||
-    false
-  );
+    false;
 }
 
 module.exports.runOnlyUTs = runOnlyUTs;
@@ -50,6 +46,8 @@ function getTestBrowser(commandLineArgs) {
       return "Firefox";
     case "chrome":
       return "Chrome";
+    case "chrome-headless":
+      return "ChromeHeadless";
 
     default:
       console.log(
@@ -105,8 +103,7 @@ function filterPackagesToTest(packagesTestMetadata, packagesToTest) {
   }
 
   return packagesTestMetadata.filter(({ packageName }) =>
-    packagesToTest.includes(packageName)
-  );
+    packagesToTest.includes(packageName));
 }
 
 module.exports.filterPackagesToTest = filterPackagesToTest;


### PR DESCRIPTION
Should only work with Mac, Linux and Chrome 59. Not tested yet.