### PR TITLE
fix(html-loader): uses require instead of AliasRegistry.getClass

### DIFF
--- a/html-loader/index.js
+++ b/html-loader/index.js
@@ -5,6 +5,6 @@ module.exports = function htmlLoader(htmlSource) {
   // of the loader return value.
   const jsonStringHTMLTemplate = JSON.stringify(htmlSource);
 
-  return `var HTMLResourceService = require('br/AliasRegistry').getClass('br.html-service');
-	HTMLResourceService.registerHTMLFileContents(${jsonStringHTMLTemplate})`;
+  return `var HTMLResourceService = require('alias!br.html-service');
+  HTMLResourceService.registerHTMLFileContents(${jsonStringHTMLTemplate})`;
 };


### PR DESCRIPTION
 - The use of require ensures that the html-service class is bundled.