### PR TITLE
When building set NODE_ENV to "production" to ensure react and other …

### DIFF
--- a/webpack-config-app/build.js
+++ b/webpack-config-app/build.js
@@ -14,7 +14,8 @@ module.exports = function configureBuildDependentConfig(
   if (isBuild) {
     const definitions = {
       "process.env": {
-        VERSION: JSON.stringify(version)
+        VERSION: JSON.stringify(version),
+        NODE_ENV: JSON.stringify("production")
       }
     };
 


### PR DESCRIPTION
…libraries run in production mode.