### PR TITLE
CT5UP-513 - Log when browser disconnects when running tests

### DIFF
--- a/karma-log-update-reporter/index.js
+++ b/karma-log-update-reporter/index.js
@@ -39,6 +39,10 @@ function logMessage({ testsType, basePath, browser }, message) {
   return logUpdate(`${basePath} ${testsType} in ${browser}: ${message}`);
 }
 
+function getPackageName(path) {
+  return path.substring(path.lastIndexOf("/") + 1)
+}
+
 function formatErrorText(errorText) {
   if (errorText === null) {
     return `\n  Error text is null.`
@@ -86,6 +90,7 @@ function LogUpdateReporter(karmaConfig) {
     error: false
   };
   this.basePath = formatBasePath(karmaConfig.basePath);
+  this.packageName = getPackageName(this.basePath);
   this.testsType = karmaConfig.testsType;
 }
 
@@ -122,6 +127,12 @@ LogUpdateReporter.prototype.onSpecComplete = function(browser, result) {
 };
 
 LogUpdateReporter.prototype.onRunComplete = function(browsers, results) {
+  if (results.disconnected) {
+    results.error = true;
+    results.packageName = this.packageName;
+    throw new Error("Browser Disconnected!");
+  }
+
   this.endDate = new Date();
   logMessage(this, testsStatus(this, results));
 

--- a/karma-test-runner/dist/utils.js
+++ b/karma-test-runner/dist/utils.js
@@ -62,6 +62,7 @@ function showSummary(results, watching) {
   let failed = 0;
   let skipped = 0;
   let success = 0;
+  let disconnected = [];
 
   for (const result of results) {
     error = error || result.error;
@@ -69,6 +70,9 @@ function showSummary(results, watching) {
     // `skipped` is only set to a number if there are skipped tests.
     skipped += result.skipped || 0;
     success += result.success;
+    if (result.disconnected) {
+      disconnected.push(result.packageName);
+    }
   }
 
   let status = `\nspecs: ${failed + skipped + success}`;
@@ -87,6 +91,10 @@ function showSummary(results, watching) {
 
   if (error === true) {
     status = `${status}, error: true`;
+  }
+
+  if (disconnected.length > 0) {
+    status = `${status} \n${disconnected.length} packages disconnected:\n${disconnected.join("\n")}`;
   }
 
   if (failed > 0 || error) {

--- a/karma-test-runner/src/utils.js
+++ b/karma-test-runner/src/utils.js
@@ -41,6 +41,7 @@ function showSummary(results, watching) {
   let failed = 0;
   let skipped = 0;
   let success = 0;
+  let disconnected = [];
 
   for (const result of results) {
     error = error || result.error;
@@ -48,6 +49,9 @@ function showSummary(results, watching) {
     // `skipped` is only set to a number if there are skipped tests.
     skipped += result.skipped || 0;
     success += result.success;
+    if (result.disconnected) {
+      disconnected.push(result.packageName)
+    }
   }
 
   let status = `\nspecs: ${failed + skipped + success}`;
@@ -66,6 +70,10 @@ function showSummary(results, watching) {
 
   if (error === true) {
     status = `${status}, error: true`;
+  }
+
+  if (disconnected.length > 0) {
+    status = `${status} \n${disconnected.length} packages disconnected:\n${disconnected.join("\n")}`;
   }
 
   if (failed > 0 || error) {


### PR DESCRIPTION
Currently when the browser disconnects when tests are running, no error is thrown and output says success.

@jngo00 @briandipalma @bit-shifter 