### PR TITLE
Allow tests to run in nested sub dir of "apps"

### DIFF
--- a/karma-test-runner/test-runner.js
+++ b/karma-test-runner/test-runner.js
@@ -8,11 +8,15 @@ const {
 } = require("./test-runner-single-file");
 
 function runTests(searchDir, argv) {
+  const cleanCoverage = argv.k;
+  const directoryNestLevel = argv.n;
   const pathParts = searchDir.split(sep);
   const appOrPkgName = pathParts.pop();
-  const appOrPkgDir = pathParts.pop();
-  const nestedAppOrPkgDir = pathParts.pop(); // Allows for one layer of nested subdirs
-  const cleanCoverage = !argv.keepCoverage;
+
+  let appOrPkgDir = pathParts.pop();
+  for (i = 0; i < directoryNestLevel; i++) {
+    appOrPkgDir = pathParts.pop();
+  }
 
   if (cleanCoverage) {
     fs.removeSync("./coverage");
@@ -22,7 +26,7 @@ function runTests(searchDir, argv) {
     console.log(`Running tests in ${argv._[0]}`);
 
     runSingleTestFile(searchDir, argv);
-  } else if (appOrPkgDir === "apps" || nestedAppOrPkgDir === "apps") {
+  } else if (appOrPkgDir === "apps") {
     console.log(`Running tests for ${appOrPkgName} application.`);
 
     runAppTests(searchDir, argv);

--- a/karma-test-runner/test-runner.js
+++ b/karma-test-runner/test-runner.js
@@ -11,6 +11,7 @@ function runTests(searchDir, argv) {
   const pathParts = searchDir.split(sep);
   const appOrPkgName = pathParts.pop();
   const appOrPkgDir = pathParts.pop();
+  const nestedAppOrPkgDir = pathParts.pop(); // Allows for one layer of nested subdirs
   const cleanCoverage = !argv.keepCoverage;
 
   if (cleanCoverage) {
@@ -21,7 +22,7 @@ function runTests(searchDir, argv) {
     console.log(`Running tests in ${argv._[0]}`);
 
     runSingleTestFile(searchDir, argv);
-  } else if (appOrPkgDir === "apps") {
+  } else if (appOrPkgDir === "apps" || nestedAppOrPkgDir === "apps") {
     console.log(`Running tests for ${appOrPkgName} application.`);
 
     runAppTests(searchDir, argv);


### PR DESCRIPTION
We are moving the mobile web app to converted/apps/mobile/webapp, however I wasn't able to run the test as currently the test runner only allows tests to be run from one directory below "apps" or "caplin-packages". I have therefore made added a CLI argument "-n" to specify the nesting level of the app or package directory. Usage example `yarn test -b headless -n 1`