### PR TITLE
feat(test-runner): Allow tests to run for apps not in apps dir

### DIFF
--- a/karma-test-runner/test-runner.js
+++ b/karma-test-runner/test-runner.js
@@ -11,6 +11,7 @@ function runTests(searchDir, argv) {
   const pathParts = searchDir.split(sep);
   const appOrPkgName = pathParts.pop();
   const appOrPkgDir = pathParts.pop();
+  const isApp = argv.app;
   const cleanCoverage = !argv.keepCoverage;
 
   if (cleanCoverage) {
@@ -21,7 +22,7 @@ function runTests(searchDir, argv) {
     console.log(`Running tests in ${argv._[0]}`);
 
     runSingleTestFile(searchDir, argv);
-  } else if (appOrPkgDir === "apps") {
+  } else if (appOrPkgDir === "apps" || isApp) {
     console.log(`Running tests for ${appOrPkgName} application.`);
 
     runAppTests(searchDir, argv);


### PR DESCRIPTION
Added --app flag to force tests to run. This is needed because we are moving the mobile web app to converted/apps/mobile/webapp and currently tests can only be run from one directory beneath apps or caplin-packages. Usage example `yarn test -b headless --app`