### PR TITLE
fix(webpack-config): Remove Uglify from Webpack config

### DIFF
--- a/webpack-config-app/build.js
+++ b/webpack-config-app/build.js
@@ -1,26 +1,23 @@
-const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
 const { DefinePlugin } = require("webpack");
 
-const { STATIC_DIR, UGLIFY_OPTIONS } = require("./config");
+const { STATIC_DIR } = require("./config");
 
 module.exports = function configureBuildDependentConfig(
   webpackConfig,
   version,
-  uglifyOptions = UGLIFY_OPTIONS,
   isBuild
 ) {
   if (isBuild) {
     const definitions = {
       "process.env": {
         VERSION: JSON.stringify(version),
-        NODE_ENV: JSON.stringify("production")
-      }
+        NODE_ENV: JSON.stringify("production"),
+      },
     };
 
     webpackConfig.mode = "production";
     webpackConfig.output.publicPath = `${STATIC_DIR}/`;
     webpackConfig.plugins.push(new DefinePlugin(definitions));
-    webpackConfig.plugins.push(new UglifyJSPlugin(uglifyOptions));
   } else {
     webpackConfig.mode = "development";
   }

--- a/webpack-config-app/config.js
+++ b/webpack-config-app/config.js
@@ -5,40 +5,36 @@ module.exports.BASE_WEBPACK_CONFIG = {
     rules: [
       {
         test: /\.html$/,
-        loader: "@caplin/html-loader"
+        loader: "@caplin/html-loader",
       },
       {
         test: /\.(cur|eot|gif|jpg|png|svg|ttf|woff|woff2)$/,
-        loader: "file-loader"
+        loader: "file-loader",
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"]
+        use: ["style-loader", "css-loader"],
       },
       {
         test: /\.xml$/,
-        loader: "@caplin/xml-loader"
+        loader: "@caplin/xml-loader",
       },
       {
         test: /\.tsx?$/,
-        loader: "ts-loader"
-      }
-    ]
+        loader: "ts-loader",
+      },
+    ],
   },
   resolve: {
     // Empty object required for `aliases` module
     alias: {},
-    extensions: [".js", ".ts", ".tsx", ".jsx", ".json"]
+    extensions: [".js", ".ts", ".tsx", ".jsx", ".json"],
   },
   performance: {
     // Turn off performance hint warnings.
-    hints: false
+    hints: false,
   },
-  plugins: [new AliasesPlugin()]
+  plugins: [new AliasesPlugin()],
 };
 
 module.exports.STATIC_DIR = "static";
-
-module.exports.UGLIFY_OPTIONS = {
-  exclude: /i18n(.*)\.js/
-};

--- a/webpack-config-app/index.js
+++ b/webpack-config-app/index.js
@@ -30,7 +30,6 @@ module.exports.webpackConfigGenerator = function webpackConfigGenerator({
   version = "dev",
   i18nFileName = `i18n-${version}.js`,
   patchesOptions,
-  uglifyOptions
 }) {
   // Object.create won't work as webpack only uses enumerable own properties.
   const webpackConfig = Object.assign({}, BASE_WEBPACK_CONFIG);
@@ -42,7 +41,7 @@ module.exports.webpackConfigGenerator = function webpackConfigGenerator({
   configureI18nLoading(webpackConfig, i18nFileName, isTest);
   configureAliases(webpackConfig, basePath);
   configureDevtool(webpackConfig, sourcemaps);
-  configureBuildDependentConfig(webpackConfig, version, uglifyOptions, isBuild);
+  configureBuildDependentConfig(webpackConfig, version, isBuild);
   configurePatches(webpackConfig, patchesOptions);
 
   // `file:` (npm 5) and `link:` (yarn) dependencies are symlinked to instead
@@ -61,7 +60,7 @@ module.exports.webpackConfigGenerator = function webpackConfigGenerator({
   // `node_modules`, and the application's `node_modules` folder.
   webpackConfig.resolve.modules = [
     "node_modules",
-    resolve(basePath, "node_modules")
+    resolve(basePath, "node_modules"),
   ];
 
   return webpackConfig;

--- a/webpack-config-app/package.json
+++ b/webpack-config-app/package.json
@@ -27,7 +27,6 @@
     "style-loader": "^0.20.0",
     "ts-loader": "^6.0.4",
     "typescript": "^3.4.3",
-    "uglifyjs-webpack-plugin": "^1.0.0",
     "webpack": "^4.0.0"
   },
   "devDependencies": {

--- a/webpack-config-app/test/build-test.js
+++ b/webpack-config-app/test/build-test.js
@@ -1,53 +1,40 @@
 const { expect } = require("chai");
-const {
-  STATIC_DIR,
-  UGLIFY_OPTIONS,
-  BASE_WEBPACK_CONFIG
-} = require("../config");
+const { STATIC_DIR, BASE_WEBPACK_CONFIG } = require("../config");
 const configureBuildDependentConfig = require("../build");
 
 describe("Webpack config app build tests.", () => {
-  it("sets publicPath and plugins properties when isBuild is set to true.", propsSet => {
+  it("sets publicPath and plugins properties when isBuild is set to true.", (propsSet) => {
     let webpackConfig = Object.assign({}, BASE_WEBPACK_CONFIG);
     webpackConfig.output = {};
     const version = "1.5.4";
     const isBuild = true;
     const definitions = {
       "process.env": {
-        "NODE_ENV": "\"production\"",
-        VERSION: JSON.stringify(version)
-      }
+        NODE_ENV: '"production"',
+        VERSION: JSON.stringify(version),
+      },
     };
 
-    configureBuildDependentConfig(
-      webpackConfig,
-      version,
-      UGLIFY_OPTIONS,
-      isBuild
-    );
+    configureBuildDependentConfig(webpackConfig, version, isBuild);
 
     expect(webpackConfig.output).to.have.property("publicPath");
     expect(webpackConfig.output.publicPath).to.equal(`${STATIC_DIR}/`);
 
     expect(webpackConfig).to.have.property("plugins");
     expect(webpackConfig.plugins[1].definitions).to.eql(definitions);
-    expect(webpackConfig.plugins[2].options).to.include(UGLIFY_OPTIONS);
     propsSet();
   });
 
-  it("doesn't set publicPath and plugins properties when isBuild is set to false.", propsSet => {
+  it("doesn't set publicPath and plugins properties when isBuild is set to false.", (propsSet) => {
     const webpackConfig = Object.assign({}, BASE_WEBPACK_CONFIG);
     const version = "1.5.4";
     const isBuild = false;
 
-    configureBuildDependentConfig(
-      webpackConfig,
-      version,
-      UGLIFY_OPTIONS,
-      isBuild
-    );
+    configureBuildDependentConfig(webpackConfig, version, isBuild);
 
-    expect(webpackConfig).to.eql(Object.assign({}, BASE_WEBPACK_CONFIG));
+    expect(webpackConfig).to.eql(
+      Object.assign({ mode: "development" }, BASE_WEBPACK_CONFIG)
+    );
     propsSet();
   });
 });

--- a/webpack-config-app/test/entry-test.js
+++ b/webpack-config-app/test/entry-test.js
@@ -4,13 +4,13 @@ const { expect } = require("chai");
 const { join } = require("path");
 
 describe("Webpack config app entry tests.", () => {
-  it("adds 'entry' property to webpack config when variant is defined.", entryAdded => {
+  it("adds 'entry' property to webpack config when variant is defined.", (entryAdded) => {
     const webpackConfig = Object.assign({}, BASE_WEBPACK_CONFIG);
     const variant = "main";
     const basePath = "./";
 
     const reactErrorOverlay = require.resolve("react-error-overlay");
-    const entryFile = `index-${variant}.js`;
+    const entryFile = `index.js`;
     const appEntryPoint = join(basePath, "src", entryFile);
 
     configureBundleEntryPoint(variant, webpackConfig, basePath);
@@ -22,7 +22,7 @@ describe("Webpack config app entry tests.", () => {
     entryAdded();
   });
 
-  it("adds 'entry' property to webpack config when variant is undefined.", entryAdded => {
+  it("adds 'entry' property to webpack config when variant is undefined.", (entryAdded) => {
     const webpackConfig = Object.assign({}, BASE_WEBPACK_CONFIG);
     const variant = undefined;
     const basePath = "./";


### PR DESCRIPTION
In production builds Webpack provides Terser by default so there
is no longer any need to add Uglify too. Adding two minifiers to
the build caused issues where multiple passes on already minified
code like packages such as `interact` would output incorrect code

BREAKING CHANGE: `uglifyOptions` has now been removed from the
Webpack options. To configure Terser follow the instructions in:
https://v4.webpack.js.org/configuration/optimization/#optimizationminimizer